### PR TITLE
Note about Windows and Linux

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -101,7 +101,8 @@ hoodie.store.findAll(type)
         <h1>Getting started</h1>
         <p class="alert">Hoodie is currently a developer preview. Some features are missing, some things might change, there's a lot of optimization to be done. Don't use this for production.</p>
         <h2>Installing Hoodie and its dependencies</h2>
-        <p>Hoodie currently only runs on OS X and requires <a href="http://mxcl.github.com/homebrew/">homebrew</a>. First, you need to install node.js and CouchDB, since the core of Hoodie is built with these:</p>
+        <p>Hoodie has support for Mac, Windows and Linux. Information about installing Hoodie on Windows and Linux can be found <a href="https://gist.github.com/Acconut/5383324">here</a>.</p>
+        <p>To get Hoodie working on OS X you need <a href="http://mxcl.github.com/homebrew/">homebrew</a>. First, you have to install node.js and CouchDB, since these power the core of Hoodie:</p>
         <pre><code class="language-none">$ brew install node
 $ brew install couchdb</code></pre>
         <p>Now install local-tld, which handles the dev domains:</p>


### PR DESCRIPTION
Since there's a stable way to use hoodie on windows and linux, we should add a note onto [hood.ie](http://hood.ie) that hoodie isn't OS X-only.
