### PR TITLE
Use the new cli

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -117,9 +117,8 @@ $ brew install node
 $ brew install couchdb</code></pre>
         <p>Now install local-tld, which handles the dev domains:</p>
         <pre><code class="language-none">$ npm install -g local-tld</code></pre>
-        <p>And finally, install Hoodie itself (we'll put this on homebrew proper soon):</p>
-        <pre><code class="language-none">$ brew tap hoodiehq/homebrew-hoodie</code></pre>
-        <pre><code class="language-none">$ brew install hoodie</code></pre>
+        <p>And finally, install Hoodie itself:</p>
+        <pre><code class="language-none">$ npm install -g hoodie-cli</code></pre>
         <p>Installation done! Time to build apps.</p>
         <h2>Creating a Hoodie app</h2>
         <pre><code class="language-none">$ hoodie new myappname</code></pre>

--- a/dist/index.html
+++ b/dist/index.html
@@ -115,9 +115,8 @@ $ brew install node
 $ brew install couchdb</code></pre>
         <p>Now install local-tld, which handles the dev domains:</p>
         <pre><code class="language-none">$ npm install -g local-tld</code></pre>
-        <p>And finally, install Hoodie itself (we'll put this on homebrew proper soon):</p>
-        <pre><code class="language-none">$ brew tap hoodiehq/homebrew-hoodie</code></pre>
-        <pre><code class="language-none">$ brew install hoodie</code></pre>
+        <p>And finally, install Hoodie itself:</p>
+        <pre><code class="language-none">$ npm install -g hoodie-cli</code></pre>
         <p>Installation done! Time to build apps.</p>
         <h2>Creating a Hoodie app</h2>
         <pre><code class="language-none">$ hoodie new myappname</code></pre>


### PR DESCRIPTION
We now have the cli written in node.
There are no reasons why we should keep the homebrew version on hood.ie.
